### PR TITLE
App Transport Security Settings에 Allow Arbitary Loads 추가

### DIFF
--- a/Idea-Archive/Support/Info.plist
+++ b/Idea-Archive/Support/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>


### PR DESCRIPTION
## 개요 💡
App Transport Security Settings에 Allow Arbitary Loads 추가

## 작업 내용 💻
https가 아닌 http로 url을 설정했을때 나오는 -1002오류를 해결했습니다.

## 리뷰해주세요 🙏
환영!