### PR TITLE
🔀 :: CI 스크립트 이름 다시 짓기

### DIFF
--- a/.github/workflows/ia_swift_ci.yml
+++ b/.github/workflows/ia_swift_ci.yml
@@ -32,18 +32,18 @@ jobs:
            -enableCodeCoverage YES | xcpretty --color
            -showBuildTimingSummary
            
-    - name: IA Android CI Discord Notification
+    - name: IA Ios CI Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ success() }}
       with:
-        title: ✅ Idea Archieve Android CI success ✅
+        title: ✅ Idea Archieve Ios CI success ✅
         webhook: ${{ secrets.IOS_DISCORD_WEBHOOK }}
         color: 00FF00
 
-    - name: IA Android CI Discord Notification
+    - name: IA Ios CI Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ failure() }}
       with:
-        title: ❗️ Idea Archieve Android CI failed ❗️
+        title: ❗️ Idea Archieve Ios CI failed ❗️
         webhook: ${{ secrets.IOS_DISCORD_WEBHOOK }}
         color: FF0000

--- a/.github/workflows/ia_swift_ci.yml
+++ b/.github/workflows/ia_swift_ci.yml
@@ -32,18 +32,18 @@ jobs:
            -enableCodeCoverage YES | xcpretty --color
            -showBuildTimingSummary
            
-    - name: IA Ios CI Discord Notification
+    - name: IA iOS CI Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ success() }}
       with:
-        title: ✅ Idea Archieve Ios CI success ✅
+        title: ✅ Idea Archive iOS CI success ✅
         webhook: ${{ secrets.IOS_DISCORD_WEBHOOK }}
         color: 00FF00
 
-    - name: IA Ios CI Discord Notification
+    - name: IA iOS CI Discord Notification
       uses: sarisia/actions-status-discord@v1
       if: ${{ failure() }}
       with:
-        title: ❗️ Idea Archieve Ios CI failed ❗️
+        title: ❗️ Idea Archive iOS CI failed ❗️
         webhook: ${{ secrets.IOS_DISCORD_WEBHOOK }}
         color: FF0000


### PR DESCRIPTION
CI 스크립트의 혼동성을 줄이기 위해 Name 을 다시 명명하였습니다. 